### PR TITLE
hardcode version number for dependency

### DIFF
--- a/src/cli/make.ts
+++ b/src/cli/make.ts
@@ -15,9 +15,6 @@ import {
 import {
   SingleBar,
 } from 'cli-progress';
-import pkg from '../../package.json' with {
-  type: 'json'
-};
 
 export default (args: string[], cwd: string,) => {
   const name = (args[FIRST_ARGUMENT] || 'benchmark')
@@ -70,7 +67,7 @@ export default (args: string[], cwd: string,) => {
       private: true,
       type: 'module',
       dependencies: {
-        '@idrinth-api-bench/framework': '^' + pkg.version,
+        '@idrinth-api-bench/framework': '^1.0.5',
       },
       devDependencies: {
         typescript: '^5.3.3',


### PR DESCRIPTION
# The Pull Request is ready

- [ ] fixes #undefined
- [ ] all actions are passing
- [ ] only fixes a single issue

## Overview

version number for @idrinth-api-bench/framework dependency is now hardcoded to version 1.0.5

## CLI

- [ ] the change works with both supported node versions
- [ ] the default behaviour did not change
- [ ] shared code has been extracted in a different file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved clarity in dependency management by specifying a static version for the `@idrinth-api-bench/framework` package.
  
- **Bug Fixes**
	- Enhanced stability in the setup process by removing unnecessary import of the package.json file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->