### PR TITLE
Unify binary files for npx

### DIFF
--- a/bin/iabc.js
+++ b/bin/iabc.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import make from '../src/cli/make.js';
+import create from '../src/cli/curl-route-builder.js';
+
+// Retrieve command-line arguments
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (command === undefined) {
+    make(process.argv, process.cwd(),);
+}
+else {
+    if (command === "curl" || command === "har" || command === "open-api"){
+        create(process.argv, process.cwd(),);
+    }
+    else {
+        throw new Error("unknown command: " + command);
+    }
+}
+
+

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "iabgbfh": "bin/generate-benchmark-from-har.js",
     "iabmp": "bin/make-benchmark-project.js",
     "iabgfoa": "bin/generate-benchmark-from-open-api.js",
-    "iabgbfc": "bin/generate-benchmark-from-curl.js"
+    "iabgbfc": "bin/generate-benchmark-from-curl.js",
+    "iabc": "bin/iabc.js"
   },
   "scripts": {
     "lint": "eslint . --ext .js,.ts,.cjs,.json,.tsx",

--- a/src/cli/make.ts
+++ b/src/cli/make.ts
@@ -15,9 +15,6 @@ import {
 import {
   SingleBar,
 } from 'cli-progress';
-import pkg from '../../package.json' with {
-  type: 'json'
-};
 
 export default (args: string[], cwd: string,) => {
   const name = (args[FIRST_ARGUMENT] || 'benchmark')
@@ -70,7 +67,7 @@ export default (args: string[], cwd: string,) => {
       private: true,
       type: 'module',
       dependencies: {
-        '@idrinth-api-bench/framework': '^' + pkg.version,
+        '@idrinth-api-bench/framework': '^1.0.5',
       },
       devDependencies: {
         typescript: '^5.3.3',


### PR DESCRIPTION
# The Pull Request is ready

- [x] fixes idrinth-api-bench/issues#1118
- [ ] all actions are passing
- [x] only fixes a single issue

## Overview

There is now an npx command iabc that is used to create all benchmark projects. It accepts arguments "curl", "har", and "open-api" for respective creation modes.  If no argument is added, it creates the default benchmark. 

eg. npx iabc

## Review points

The previous commands are still included in the project. Should they all be removed?

## CLI

- [ ] the change works with both supported node versions
- [ ] the default behaviour did not change
- [ ] shared code has been extracted in a different file


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line interface (CLI) utility for enhanced command execution.
	- Added support for multiple commands, improving user interaction with the CLI.
  
- **Chores**
	- Updated `package.json` to include the new CLI script, expanding available functionalities while preserving existing ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->