### PR TITLE
Unify npx commands into one 

### DIFF
--- a/bin/generate-benchmark-from-curl.js
+++ b/bin/generate-benchmark-from-curl.js
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import create from '../src/cli/curl-route-builder.js';
-
-create(process.argv, process.cwd(),);

--- a/bin/generate-benchmark-from-har.js
+++ b/bin/generate-benchmark-from-har.js
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import create from '../src/cli/har-route-builder.js';
-
-create(process.argv, process.cwd(),);

--- a/bin/generate-benchmark-from-open-api.js
+++ b/bin/generate-benchmark-from-open-api.js
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import create from '../src/cli/open-api-route-builder.js';
-
-create(process.argv, process.cwd(),);

--- a/bin/iabc.js
+++ b/bin/iabc.js
@@ -19,6 +19,7 @@ switch (command) {
         break;
     case "open-api":
         openApiCreate(process.argv.splice(2, 1), process.cwd())
+        break;
     default:
         throw new Error("unknown command: " + command);
 }

--- a/bin/iabc.js
+++ b/bin/iabc.js
@@ -1,21 +1,24 @@
 #!/usr/bin/env node
 import make from '../src/cli/make.js';
-import create from '../src/cli/curl-route-builder.js';
+import harCreate from '../src/cli/har-route-builder.js';
+import openApiCreate from '../src/cli/open-api-route-builder.js';
+import curlCreate from '../src/cli/curl-route-builder.js';
 
-// Retrieve command-line arguments
-const args = process.argv.slice(2);
-const command = args[0];
+//get command from command line arguments
+const command = process.argv[2];
 
-if (command === undefined) {
-    make(process.argv, process.cwd(),);
-}
-else {
-    if (command === "curl" || command === "har" || command === "open-api"){
-        create(process.argv, process.cwd(),);
-    }
-    else {
+switch (command) {
+    case undefined:
+        make(process.argv.splice(2, 1), process.cwd(),);
+        break;
+    case ("curl"):
+        curlCreate(process.argv.splice(2, 1), process.cwd())
+        break;
+    case ("har"):
+        harCreate(process.argv.splice(2, 1), process.cwd())
+        break;
+    case "open-api":
+        openApiCreate(process.argv.splice(2, 1), process.cwd())
+    default:
         throw new Error("unknown command: " + command);
-    }
 }
-
-

--- a/bin/iabc.js
+++ b/bin/iabc.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+import make from '../src/cli/make.js';
+import create from '../src/cli/curl-route-builder.js';
+
+// Retrieve command-line arguments
+const args = process.argv.slice(2);
+const command = args[0];
+
+if (command === undefined) {
+    make(process.argv, process.cwd(),);
+}
+else {
+    if (command === "curl" || command === "har" || command === "open-api"){
+        create(process.argv, process.cwd(),);
+    }
+    else {
+        throw new Error("unknown command: " + command);
+    }
+}
+
+

--- a/bin/iabc.js
+++ b/bin/iabc.js
@@ -1,21 +1,8 @@
 #!/usr/bin/env node
-import make from '../src/cli/make.js';
-import create from '../src/cli/curl-route-builder.js';
+import handleCommand from "../src/cli/handle-command.js"
 
-// Retrieve command-line arguments
-const args = process.argv.slice(2);
-const command = args[0];
-
-if (command === undefined) {
-    make(process.argv, process.cwd(),);
+try {
+    handleCommand(process.argv, process.cwd())
+}catch(error){
+    console.error(error)
 }
-else {
-    if (command === "curl" || command === "har" || command === "open-api"){
-        create(process.argv, process.cwd(),);
-    }
-    else {
-        throw new Error("unknown command: " + command);
-    }
-}
-
-

--- a/bin/make-benchmark-project.js
+++ b/bin/make-benchmark-project.js
@@ -1,4 +1,0 @@
-#!/usr/bin/env node
-import make from '../src/cli/make.js';
-
-make(process.argv, process.cwd(),);

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "generate-benchmark-from-curl": "bin/generate-benchmark-from-curl.js",
         "generate-benchmark-from-har": "bin/generate-benchmark-from-har.js",
         "generate-benchmark-from-open-api": "bin/generate-benchmark-from-open-api.js",
+        "iabc": "bin/iabc.js",
         "iabgbfc": "bin/generate-benchmark-from-curl.js",
         "iabgbfh": "bin/generate-benchmark-from-har.js",
         "iabgfoa": "bin/generate-benchmark-from-open-api.js",

--- a/package.json
+++ b/package.json
@@ -60,14 +60,6 @@
     "knip": "^5.23.3"
   },
   "bin": {
-    "make-benchmark-project": "bin/make-benchmark-project.js",
-    "generate-benchmark-from-open-api": "bin/generate-benchmark-from-open-api.js",
-    "generate-benchmark-from-har": "bin/generate-benchmark-from-har.js",
-    "generate-benchmark-from-curl": "bin/generate-benchmark-from-curl.js",
-    "iabgbfh": "bin/generate-benchmark-from-har.js",
-    "iabmp": "bin/make-benchmark-project.js",
-    "iabgfoa": "bin/generate-benchmark-from-open-api.js",
-    "iabgbfc": "bin/generate-benchmark-from-curl.js",
     "iabc": "bin/iabc.js"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "iabgbfh": "bin/generate-benchmark-from-har.js",
     "iabmp": "bin/make-benchmark-project.js",
     "iabgfoa": "bin/generate-benchmark-from-open-api.js",
-    "iabgbfc": "bin/generate-benchmark-from-curl.js"
+    "iabgbfc": "bin/generate-benchmark-from-curl.js",
+    "iabc": "bin/iabc.js"
   },
   "scripts": {
     "lint": "eslint . --ext .js,.ts,.cjs,.json,.tsx",

--- a/src/cli/handle-command.ts
+++ b/src/cli/handle-command.ts
@@ -1,0 +1,16 @@
+import make from "./make.js";
+import create from "./curl-route-builder.js";
+
+export default function handleCommand(args: string[], cwd: string) {
+  const command = args[2];
+
+  if (command === undefined) {
+    make(args, cwd);
+  } else {
+    if (command === "curl" || command === "har" || command === "open-api") {
+      create(args, cwd);
+    } else {
+      throw new Error("unknown command: " + command);
+    }
+  }
+}

--- a/src/cli/make.ts
+++ b/src/cli/make.ts
@@ -15,9 +15,6 @@ import {
 import {
   SingleBar,
 } from 'cli-progress';
-import pkg from '../../package.json' with {
-  type: 'json'
-};
 
 export default (args: string[], cwd: string,) => {
   const name = (args[FIRST_ARGUMENT] || 'benchmark')
@@ -70,7 +67,7 @@ export default (args: string[], cwd: string,) => {
       private: true,
       type: 'module',
       dependencies: {
-        '@idrinth-api-bench/framework': '^' + pkg.version,
+        '@idrinth-api-bench/framework': '^1.0.5',
       },
       devDependencies: {
         typescript: '^5.3.3',


### PR DESCRIPTION
# The Pull Request is ready

- [ ] fixes #1118
- [ ] all actions are passing
- [ ] only fixes a single issue

## Overview

There is now an npx command iabc that is used to create all benchmark projects. It accepts arguments "curl", "har", and "open-api" for respective creation modes. If no argument is added, it creates the default benchmark.

eg. npx iabc

The old npx commands have been removed from package.json, as well as their files inside the bin directory.

## CLI

- [ ] the change works with both supported node versions
- [ ] the default behaviour did not change
- [ ] shared code has been extracted in a different file

## Notes

<!-- Write any note or comment. You can share your thoughts or ideas. -->
<!-- Delete this section if not needed -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new command-line interface (CLI) utility for command processing, enhancing user interactions.
	- Consolidated multiple benchmarking scripts into a single command for streamlined functionality.

- **Bug Fixes**
	- Improved error handling for unrecognized commands in the CLI.

- **Chores**
	- Restructured package.json to remove outdated scripts and focus on the new CLI tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->